### PR TITLE
chore: Remove explicit CFBundleShortVersionString and CFBundleVersion

### DIFF
--- a/src/DailyPlants/Platforms/iOS/Info.plist
+++ b/src/DailyPlants/Platforms/iOS/Info.plist
@@ -7,10 +7,6 @@
 		<string>Daily Plants</string>
 		<key>CFBundleName</key>
 		<string>DailyPlants</string>
-		<key>CFBundleShortVersionString</key>
-		<string>1.0.0</string>
-		<key>CFBundleVersion</key>
-		<string>1</string>
 
 		<!-- Device requirements -->
 		<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
closes https://github.com/MartinZikmund/daily-dozen/issues/13

Removed versioning keys from Info.plist.

## Description

Brief description of the changes in this PR.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update

## Changes Made

- Change 1
- Change 2
- Change 3

## Screenshots (if applicable)

| Before | After |
|--------|-------|
| image  | image |

## Testing

Describe the tests you ran to verify your changes:

- [ ] Tested on Windows
- [ ] Tested on Android
- [ ] Tested on iOS
- [ ] Tested on WebAssembly
- [ ] Unit tests pass
- [ ] Manual testing completed

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged

## Additional Notes

Any additional information that reviewers should know.
